### PR TITLE
Add new error on get asset by userId

### DIFF
--- a/app/server/routes/libraries.py
+++ b/app/server/routes/libraries.py
@@ -49,7 +49,11 @@ async def get_library(
     library = await retrieve_library(id_user)
     if library:
         return ResponseModel(library)
-    return ErrorResponseModel("Not found error", 404, "User library not found.")
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="User library not found.",
+    )
 
 @LibrariesRouter.get(
     "/{id_user}/assets", 
@@ -65,9 +69,14 @@ async def get_library_assets(
             detail="You do not have permission to get library assets.",
         )
     assets = await retrieve_library_assets(id_user)
-    if assets or assets == []:
+    if assets:
         return ResponseModel(assets)
-    return ErrorResponseModel("Not found error", 404, "User library not found.")
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="User library not found.",
+    )
+
 
 @LibrariesRouter.delete(
     "/{id_user}/assets", 


### PR DESCRIPTION
Now Frontend show an error message on empty myLibrary
![image](https://github.com/aiondemand/AIOD-mylibrary-backend/assets/148339138/79322730-4d05-4e19-af5e-599a6cee3704)

And the response from backend is:

![image](https://github.com/aiondemand/AIOD-mylibrary-backend/assets/148339138/42e30d33-f9ef-4657-a8b8-6527e32cf318)

![image](https://github.com/aiondemand/AIOD-mylibrary-backend/assets/148339138/c6957a21-4d24-4c57-a3e6-6bedeb3747f1)


Before:

![image](https://github.com/aiondemand/AIOD-mylibrary-backend/assets/148339138/f2897593-502b-4aab-b5e0-05d079249ad4)

![image](https://github.com/aiondemand/AIOD-mylibrary-backend/assets/148339138/9679d3be-4892-4261-8ea7-1d24b6f3d38f)
